### PR TITLE
fix: clone() cloning prototype's custom methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,17 +37,19 @@ exports.clone = function (obj) {
   }
 
   for (var i in obj) {
-    if (Array.isArray(obj[i])) {
-      copy[i] = obj[i].slice(0);
-    }
-    else if (obj[i] instanceof Buffer) {
+    if (obj.hasOwnProperty(i)) {
+      if (Array.isArray(obj[i])) {
         copy[i] = obj[i].slice(0);
-    }
-    else if (typeof obj[i] != 'function') {
-      copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
-    }
-    else if (typeof obj[i] === 'function') {
-      copy[i] = obj[i];
+      }
+      else if (obj[i] instanceof Buffer) {
+        copy[i] = obj[i].slice(0);
+      }
+      else if (typeof obj[i] != 'function') {
+        copy[i] = obj[i] instanceof Object ? exports.clone(obj[i]) : obj[i];
+      }
+      else if (typeof obj[i] === 'function') {
+        copy[i] = obj[i];
+      }
     }
   }
 


### PR DESCRIPTION
Hi @indexzero, as you requested in [winston/1086](https://github.com/winstonjs/winston/pull/1086).