### PR TITLE
fix: require 'util'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var cycle = require('cycle');
+var util = require('util')
 
 //
 // Expose base Transport


### PR DESCRIPTION
util.inspect is used in index.js but `util` is previously not required, causing error when `prettyPrint = true`